### PR TITLE
Add :cl-messagepack dependency

### DIFF
--- a/cl-fluent-logger.asd
+++ b/cl-fluent-logger.asd
@@ -4,6 +4,6 @@
   :author "Eitaro Fukamachi"
   :license "BSD 3-Clause"
   :description "A structured logger for Fluentd"
-  :depends-on ("cl-fluent-logger/main"))
+  :depends-on ("cl-messagepack" "cl-fluent-logger/main"))
 
 (asdf:register-system-packages "cl-messagepack" '(#:messagepack))

--- a/cl-fluent-logger.asd
+++ b/cl-fluent-logger.asd
@@ -4,6 +4,6 @@
   :author "Eitaro Fukamachi"
   :license "BSD 3-Clause"
   :description "A structured logger for Fluentd"
-  :depends-on ("cl-messagepack" "cl-fluent-logger/main"))
+  :depends-on ("cl-messagepack" "pack" "cl-fluent-logger/main"))
 
 (asdf:register-system-packages "cl-messagepack" '(#:messagepack))


### PR DESCRIPTION
`:depends-on ("cl-messagepack")` may be required to compile correctly.